### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://chandan90.visualstudio.com/694f0cce-5ebf-453b-a475-e317cdda4dc5/3a367b3c-6c8e-41ce-ab46-10dd5fa628a9/_apis/work/boardbadge/8cf6ba1e-c5f5-4401-ba91-2ac31873d831)](https://chandan90.visualstudio.com/694f0cce-5ebf-453b-a475-e317cdda4dc5/_boards/board/t/3a367b3c-6c8e-41ce-ab46-10dd5fa628a9/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.